### PR TITLE
fix: update launchpad to version 0.0.19

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -23,7 +23,7 @@
         "@nomicfoundation/hardhat-toolbox": "^1.0.2",
         "@nomiclabs/hardhat-ethers": "^2.1.0",
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
-        "@taikai/dappkit-launchpad": "0.0.16",
+        "@taikai/dappkit-launchpad": "0.0.19",
         "@typechain/ethers-v5": "^10.1.0",
         "@typechain/hardhat": "^6.1.2",
         "@types/chai": "^4.3.1",
@@ -1465,9 +1465,9 @@
       }
     },
     "node_modules/@taikai/dappkit-launchpad": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@taikai/dappkit-launchpad/-/dappkit-launchpad-0.0.16.tgz",
-      "integrity": "sha512-Wm37lHUY4RwvjnIfu4EqmzDJURRqi+bZ+6A8vMnwBqD4zxrrw8kA5gqdWanj20AB2KsD4++YfUQqtc0sP6DGHQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@taikai/dappkit-launchpad/-/dappkit-launchpad-0.0.19.tgz",
+      "integrity": "sha512-6sXp4BY5QX+hlWQxOu7p1/VYS/xBK+ys25PoSbZsqOiRWJJbNsqMeqlK0QHbjhrg7JD0L/KEtBf58Qut7nEisQ==",
       "dev": true,
       "dependencies": {
         "change-case": "^4.1.2",
@@ -13982,9 +13982,9 @@
       }
     },
     "@taikai/dappkit-launchpad": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@taikai/dappkit-launchpad/-/dappkit-launchpad-0.0.16.tgz",
-      "integrity": "sha512-Wm37lHUY4RwvjnIfu4EqmzDJURRqi+bZ+6A8vMnwBqD4zxrrw8kA5gqdWanj20AB2KsD4++YfUQqtc0sP6DGHQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@taikai/dappkit-launchpad/-/dappkit-launchpad-0.0.19.tgz",
+      "integrity": "sha512-6sXp4BY5QX+hlWQxOu7p1/VYS/xBK+ys25PoSbZsqOiRWJJbNsqMeqlK0QHbjhrg7JD0L/KEtBf58Qut7nEisQ==",
       "dev": true,
       "requires": {
         "change-case": "^4.1.2",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -34,7 +34,7 @@
     "hardhat": "^2.10.1"
   },
   "devDependencies": {
-    "@taikai/dappkit-launchpad": "0.0.16",
+    "@taikai/dappkit-launchpad": "0.0.19",
     "@ethersproject/abi": "^5.6.4",
     "@ethersproject/providers": "^5.6.8",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.2",


### PR DESCRIPTION
The version 0.0.16 was generating an interface named XPromiEvent, I checked the last commits on [**dappkit-launchpad**](https://github.com/taikai/dappkit-launchpad/compare/v0.0.16...master) they removed cause its not fully implemented and it was creating an error of import path